### PR TITLE
Correct inconsistence

### DIFF
--- a/po/ja.po
+++ b/po/ja.po
@@ -69,7 +69,7 @@ msgstr "システム"
 
 #: ../src/setup.vala:520
 msgid "user"
-msgstr "ユーザ"
+msgstr "ユーザー"
 
 #: ../src/setup.vala:522
 msgid "server"
@@ -85,7 +85,7 @@ msgstr "システム"
 
 #: ../src/ibus-skk-preferences.ui.in.h:5
 msgid "User"
-msgstr "ユーザ"
+msgstr "ユーザー"
 
 #: ../src/ibus-skk-preferences.ui.in.h:6
 msgid "SKK Server"

--- a/po/ja.po
+++ b/po/ja.po
@@ -85,11 +85,11 @@ msgstr "システム"
 
 #: ../src/ibus-skk-preferences.ui.in.h:5
 msgid "User"
-msgstr "ユーザー"
+msgstr "ユーザ"
 
 #: ../src/ibus-skk-preferences.ui.in.h:6
 msgid "SKK Server"
-msgstr "SKK サーバー"
+msgstr "SKK サーバ"
 
 #: ../src/ibus-skk-preferences.ui.in.h:7
 msgid "IBus SKK Preferences"
@@ -161,7 +161,7 @@ msgstr "動作"
 
 #: ../src/ibus-skk-preferences.ui.in.h:24
 msgid "SKK input method for IBus"
-msgstr "IBus入力プラットフォーム用SKKエンジン"
+msgstr "IBus 入力プラットフォーム用 SKK エンジン"
 
 #: ../src/ibus-skk-preferences.ui.in.h:25
 msgid "About"
@@ -177,4 +177,4 @@ msgstr "IBus SKK エンジンの設定"
 
 #: ../src/skk.xml.in.in.h:2
 msgid "SKK Input Method"
-msgstr "SKK入力方式"
+msgstr "SKK 入力方式"


### PR DESCRIPTION
I corrected some inconsistent regulations for translation English to Japanese words.
* Spaces between Japanese words and English ones (e.g. 「SKK 入力方式」)
* Macrons at the end of the Katakana words (e.g. 「サーバ」)