### PR TITLE
src/Makefile.am: Also add GITIGNOREFILES to CLEANFILES

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -125,6 +125,7 @@ EXTRA_DIST =					\
 
 DISTCLEANFILES =				\
 	ibus-skk-preferences.ui			\
+	$(GITIGNOREFILES)			\
 	$(NULL)
 
 -include $(top_srcdir)/git.mk


### PR DESCRIPTION
This ensures a proper Makefile clean target.
See https://bugs.debian.org/1049244 .